### PR TITLE
Some fixes

### DIFF
--- a/src/Xavrsl/Ldap/Directory.php
+++ b/src/Xavrsl/Ldap/Directory.php
@@ -229,7 +229,7 @@ class Directory {
 		// return an array of CNs
 		$results = ldap_get_entries($this->connection, $sr);
 		for($i = 0; $i < $results['count']; $i++) {
-			$this->store($results[$i][$key][0], $results[0]);
+			$this->store($results[$i][$key][0], $results[$i]);
 		}
 	}
 


### PR DESCRIPTION
Just put in some minor changes to your library we found very useful:
1. Don't error on not-found properties—just return them as null.
2. Major bugfix—was always caching the first result in the array of a search for many usernames.

Thanks for the library!
