### PR TITLE
Add the ability to set named base filters

### DIFF
--- a/src/Directory.php
+++ b/src/Directory.php
@@ -270,7 +270,7 @@ public function addNameBasedFilters($filters) {
  * @var string  $filterName
  **/
 public function useNamedFilter($filterName) {
-	if ((isset($this->namedBaseFilters[$filterName]) || ($filterName == null)) {
+	if ((isset($this->namedBaseFilters[$filterName])) || ($filterName == null)) {
 		$this->currentFilterName = $filterName;
 		return true;
 	}

--- a/src/Directory.php
+++ b/src/Directory.php
@@ -123,11 +123,11 @@ class Directory {
 			}
 			return $this->auth($parameters[0], $parameters[1]);
 		}
-		elseif ($method == 'setNameBasedFilters') {
+		elseif ($method == 'setNamedBaseFilters') {
 			if (count($parameters) !== 1) {
 				throw new \Exception('One associative array with the named filters required');
 			}
-			return $this->setNameBasedFilters($parameters[0]);
+			return $this->setNamedBaseFilters($parameters[0]);
 		}
 		elseif ($method == 'useNamedFilter') {
 			if (count($parameters) !== 1) {
@@ -246,7 +246,7 @@ class Directory {
 	 *
 	 * @var array  $filters
 	 **/
-public function setNameBasedFilters($filters) {
+public function setNamedBaseFilters($filters) {
 		$this->namedBaseFilters = $filters;
 }
 
@@ -255,7 +255,7 @@ public function setNameBasedFilters($filters) {
  *
  * @var array  $filters
  **/
-public function addNameBasedFilters($filters) {
+public function addNamedBaseFilters($filters) {
 	if (isset($this->namedBaseFilters)) {
 		array_merge($this->namedBaseFilters, $filters);
 	}

--- a/src/config/ldap.php
+++ b/src/config/ldap.php
@@ -83,6 +83,17 @@ return [
     */
 
     'filter'        => 'login',
+    
+    /*
+    |--------------------------------------------------------------------------
+    | The key used for replacement in the named base filters.
+    | There is not great interest in modfying it
+    | You must declare your base filters with this key
+    | ex : (&(objectClass=inetOrgPerson)#filters#)
+    |--------------------------------------------------------------------------
+    */
+    'named_base_filter_key' => '#filters#',
+
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
I realized multi-attribute queries were not possible and that the module itself was not completely made for it (attributeFilter as class variable) so I implemented the ability to set named base filters to apply to the LDAP requests. Changes are made in Directory.php and config.php

From the client, it's possible to set filters
`Ldap::setNamedBaseFilters(['LDAP_EMPLOYEE_FILTER' => env('LDAP_EMPLOYEE_FILTER')]);`
There is also the ability to add filters
`Ldap::addNamedBaseFilters(['LDAP_EMPLOYEE_FILTER' => env('LDAP_EMPLOYEE_FILTER')]);`

In my .env, here I set 
`LDAP_EMPLOYEE_FILTER=(&(eduPersonAffiliation=employee)#filters#)`
It's a shame that you could not set arrays in .env but it's not a big deal.

To use the filter I set :
`Ldap::useNamedFilter('LDAP_EMPLOYEE_FILTER')`
returns true if ok or false if the name has not been set as a filter first.

Then a classic Ldap::find
`Ldap::find('people')->where('supannAliasLogin', "*$username*")->get(['cn', 'supannAliasLogin']));`

On the LDAP log side I have a request with
`filter="(&(eduPersonAffiliation=employee)(|(supannAliasLogin=*florent*)))"`
which is great for what I need.

I would be glad if you could have a look into it and integrate it or tell me what's wrong.
Thanks,
Florent.