### PR TITLE
Sanitize Instructions

### DIFF
--- a/src/Directory.php
+++ b/src/Directory.php
@@ -373,6 +373,16 @@ class Directory {
 		}
 	}
 
+	
+	/**
+	* Sanitize Inputs | Is vulnerable to LDAP injection
+	**/
+	protected function sanitize($characters){
+		$patterns = "/((?![a-zA-Z0-9\!\$\%\-\_\=\.]).)*/";
+		$characters = preg_replace($patterns, '', preg_quote(trim($characters, "\t\n\r\0\x0B" )));
+		$characters = filter_var($characters , FILTER_SANITIZE_STRING);
+		return $characters;
+	}
 	/**
 	 * Set the entries from Directory
 	 *


### PR DESCRIPTION
$filter = '(' . $this->booleanOperator;
foreach($this->requestedEntries as $requestedEntry) {
	$filter .= '(' . $this->filterAttribute . '=' . $requestedEntry . ')';
}
$filter .= ')';

It is vulnerable to an LDAP injection, it needs to be sanitize before generating the query, I am currently using this plugin, it is quite good but I did not pass an OWASP auditorium, the auditors advised me to notify this error and send a solution.

Add a function that allows the disinfection of the query, it is necessary to use it in the methods where the query is generated to ldap.